### PR TITLE
ignores .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+#MacOS
+.DS_store


### PR DESCRIPTION
Ignore all `.DS_Store` hidden files via `.gitignore` to prevent upload to source control.